### PR TITLE
fix :bug: fix props separating in autoComplete InputProps

### DIFF
--- a/packages/formalite/src/components/Formalite/elements/AutoCompleteView/AutoCompleteView.tsx
+++ b/packages/formalite/src/components/Formalite/elements/AutoCompleteView/AutoCompleteView.tsx
@@ -199,6 +199,10 @@ const AutoCompleteView = <T extends FormikValues>(
               }
               {...params}
               {...inputProps}
+              InputProps={{
+                ...(params.InputProps ? params.InputProps : {}),
+                ...(inputProps.InputProps ? inputProps.InputProps : {}),
+              }}
             />
           )}
           {...(autoCompleteProps || {})}


### PR DESCRIPTION
There was an issue with using InputProps that handles in this bugfix pull request